### PR TITLE
Initial migration of bzip2-musl from core plans.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.bzip2-musl?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=148&branchName=master)
+
+# bzip2-musl
+
+[bzip2][1] is a freely available, patent free (see below), high-quality data compressor.
+
+This package is built with [musl-libc][2].
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+To use this plan, include it in your `pkg_build_deps` or `pkg_deps`, for example:
+
+```
+pkg_build_deps=(core/bzip2-musl)
+```
+
+or use it directly:
+
+```
+hab pkg install core/bzip2-musl --binlink
+bzip2
+```
+
+[1]: http://www.bzip.org/
+[2]: https://www.musl-libc.org

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "bzip2-musl"

--- a/controls/bzip2_musl_test.rb
+++ b/controls/bzip2_musl_test.rb
@@ -1,0 +1,36 @@
+title 'Tests to confirm bzip2-musl works as expected'
+
+plan_name = input('plan_name', value: 'bzip2-musl')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-bzip2-musl' do
+  impact 1.0
+  title 'Ensure bzip2-musl works'
+  desc '
+  We confirm that the bzip2-musl binary is present in the expected location.
+
+    $ ls -al <pkg>/bin/bzip2
+
+  Next, we test for simple execution working:
+
+    $ bzip2 --version
+  '
+  bzip2_musl_pkg_ident = command("#{hab_path} pkg path #{plan_ident}")
+  describe bzip2_musl_pkg_ident do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  bzip2_musl_pkg_ident = bzip2_musl_pkg_ident.stdout.strip
+
+  describe command("ls -al #{bzip2_musl_pkg_ident}/bin/bzip2") do
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /#{bzip2_musl_pkg_ident}/}
+    its('exit_status') { should eq 0 }
+  end
+
+  describe command("#{bzip2_musl_pkg_ident}/bin/bzip2 --version") do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should match /bzip2, a block-sorting file compressor/ }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: bzip2-musl
+title: Habitat Core Plan for bzip2-musl
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan for bzip2-musl
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,86 @@
+pkg_name=bzip2-musl
+download_pkg_name=bzip2
+pkg_origin=core
+pkg_version=1.0.8
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+bzip2 is a free and open-source file compression program that uses the \
+Burrows–Wheeler algorithm. It only compresses single files and is not a file \
+archiver.\
+"
+pkg_upstream_url="http://www.bzip.org/"
+pkg_license=('bzip2')
+pkg_source="https://fossies.org/linux/misc/${download_pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
+pkg_dirname="${download_pkg_name}-${pkg_version}"
+pkg_deps=(
+  core/musl
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_prepare() {
+  # Makes the symbolic links in installation relative vs. absolute
+  # shellcheck disable=SC2016
+  sed -i 's@\(ln -s -f \)$(PREFIX)/bin/@\1@' Makefile
+
+  # Ensure that the man pages are installed under share/man
+  sed -i "s@(PREFIX)/man@(PREFIX)/share/man@g" Makefile
+
+  export CC=musl-gcc
+  build_line "Setting CC=$CC"
+
+  dynamic_linker="$(pkg_path_for musl)/lib/ld-musl-x86_64.so.1"
+  LDFLAGS="$LDFLAGS -Wl,--dynamic-linker=$dynamic_linker"
+}
+
+do_build() {
+  make -f Makefile-libbz2_so PREFIX="$pkg_prefix" CC="$CC"
+  make bzip2 bzip2recover CC="$CC" LDFLAGS="$LDFLAGS"
+}
+
+do_check() {
+  make test
+}
+
+do_install() {
+  local maj maj_min
+  maj=$(echo $pkg_version | cut -d "." -f 1)
+  maj_min=$(echo $pkg_version | cut -d "." -f 1-2)
+
+  make install PREFIX="$pkg_prefix"
+
+  # Replace some hard links with symlinks
+  rm -fv "$pkg_prefix/bin"/{bunzip2,bzcat}
+  ln -sv bzip2 "$pkg_prefix/bin/bunzip2"
+  ln -sv bzip2 "$pkg_prefix/bin/bzcat"
+
+  # Install the shared library and its symlinks
+  cp -v "$HAB_CACHE_SRC_PATH/$pkg_dirname/libbz2.so.$pkg_version" \
+    "$pkg_prefix/lib"
+  ln -sv "libbz2.so.$pkg_version" "$pkg_prefix/lib/libbz2.so"
+  ln -sv "libbz2.so.$pkg_version" "$pkg_prefix/lib/libbz2.so.$maj"
+  ln -sv "libbz2.so.$pkg_version" "$pkg_prefix/lib/libbz2.so.$maj_min"
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+  )
+fi


### PR DESCRIPTION
N.B. this moves us away from the pattern where a parent plan is sourced e.g.
https://github.com/habitat-sh/core-plans/blob/master/bzip2-musl/plan.sh#L1
```
Profile: Habitat Core Plan for bzip2-musl (bzip2-musl)
Version: 0.1.0
Target:  docker://96966734e55b97fc2372c3554ec987a6dcfbc753b2375e67cb79547b8f4d6997

  ✔  core-plans-bzip2-musl: Ensure bzip2-musl works
     ✔  Command: `hab pkg path habskp/bzip2-musl` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/bzip2-musl` stdout is expected not to be empty
     ✔  Command: `ls -al /hab/pkgs/habskp/bzip2-musl/1.0.8/20200609110817/bin/bzip2` stdout is expected not to be empty
     ✔  Command: `ls -al /hab/pkgs/habskp/bzip2-musl/1.0.8/20200609110817/bin/bzip2` stdout is expected to match /\/hab\/pkgs\/habskp\/bzip2-musl\/1.0.8\/20200609110817/
     ✔  Command: `ls -al /hab/pkgs/habskp/bzip2-musl/1.0.8/20200609110817/bin/bzip2` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/bzip2-musl/1.0.8/20200609110817/bin/bzip2 --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/bzip2-musl/1.0.8/20200609110817/bin/bzip2 --version` stderr is expected to match /bzip2, a block-sorting file compressor/
```

﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
